### PR TITLE
Support custom employee fields (fix #3)

### DIFF
--- a/lib/WebService/BambooHR/Employee.pm
+++ b/lib/WebService/BambooHR/Employee.pm
@@ -89,12 +89,13 @@ sub BUILD {
     my ( $self, $args ) = @_;
 
     for my $attribute ( grep { /^custom/ } keys %{$args} ) {
+        my $safe_attribute = $attribute =~ s/[^A-Za-z_0-9]//rg;
         $self->{$attribute} = $args->{$attribute};
 
         my $method_template = qq(
-sub $attribute {
+sub $safe_attribute {
     my \$self = shift;
-    \@_ ? \$self->{$attribute}=\$_[0] : \$self->{$attribute};
+    \@_ ? \$self->{'$attribute'}=\$_[0] : \$self->{'$attribute'};
 }
 );
         eval("$method_template; 1");

--- a/lib/WebService/BambooHR/Employee.pm
+++ b/lib/WebService/BambooHR/Employee.pm
@@ -85,6 +85,22 @@ has 'workPhoneExtension' => (is => 'ro');
 has 'workPhonePlusExtension' => (is => 'ro');
 has 'zipcode' => (is => 'ro');
 
+sub BUILD {
+    my ( $self, $args ) = @_;
+
+    for my $attribute ( grep { /^custom/ } keys %{$args} ) {
+        $self->{$attribute} = $args->{$attribute};
+
+        my $method_template = qq(
+sub $attribute {
+    my \$self = shift;
+    \@_ ? \$self->{$attribute}=\$_[0] : \$self->{$attribute};
+}
+);
+        eval("$method_template; 1");
+    }
+}
+
 1;
 
 =head1 NAME

--- a/lib/WebService/BambooHR/Employee.pm
+++ b/lib/WebService/BambooHR/Employee.pm
@@ -92,6 +92,8 @@ sub BUILD {
         my $safe_attribute = $attribute =~ s/[^A-Za-z_0-9]//rg;
         $self->{$attribute} = $args->{$attribute};
 
+        next if $self->can($safe_attribute);
+
         my $method_template = qq(
 sub $safe_attribute {
     my \$self = shift;

--- a/lib/WebService/BambooHR/UserAgent.pm
+++ b/lib/WebService/BambooHR/UserAgent.pm
@@ -30,6 +30,11 @@ has 'company' =>
         is       => 'ro',
     );
 
+has 'custom_fields' =>
+    (
+        is       => 'ro',
+    );
+
 sub _get
 {
     my $self     = shift;
@@ -229,6 +234,8 @@ sub _employee_record
 
 sub _field_list
 {
+    my $self = shift;
+    %field = ( %field, %{ $self->custom_fields } );
     return keys %field;
 }
 

--- a/lib/WebService/BambooHR/UserAgent.pm
+++ b/lib/WebService/BambooHR/UserAgent.pm
@@ -33,6 +33,7 @@ has 'company' =>
 has 'custom_fields' =>
     (
         is       => 'ro',
+        default  => sub { return {} },
     );
 
 sub _get

--- a/t/03-employee.t
+++ b/t/03-employee.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use LWP::Online ':skip_all';
-use Test::More 0.88 tests => 8;
+use Test::More 0.88 tests => 9;
 use WebService::BambooHR;
 my $domain             = 'testperl';
 my $api_key            = 'bfb359256c9d9e26b37309420f478f03ec74599b';
@@ -14,9 +14,12 @@ my $employee;
 
 SKIP: {
 
-    my $bamboo = WebService::BambooHR->new(
-                        company => $domain,
-                        api_key => $api_key);
+    my $bamboo =
+        WebService::BambooHR->new(
+                       company       => $domain,
+                       api_key       => $api_key,
+                       custom_fields => { customShirtSize => q{Shirt size}, },
+        );
     ok(defined($bamboo), "create BambooHR class");
 
     eval {
@@ -29,6 +32,7 @@ SKIP: {
     ok($employee->status eq 'Active',    'status');
     ok($employee->location eq 'Chicago', 'location');
     ok($employee->selfServiceAccess eq 'No', 'self-service access');
+    ok(defined $employee->customShirtSize, 'custom field found');
 
     eval {
         $employee = $bamboo->employee(40345, $INVALID_FIELD_NAME);


### PR DESCRIPTION
It's a crude, hackish proof of concept PR to support custom employee fields.

I'm not sure what would be the proper way to dynamically generate attributes for a Moo-based object. I'd prefer having an approach not based on `eval`.

Also, the format of passing custom fields to the constructor is up for discussion. For now, I tried to keep it consistent with the `%fields` format.

I'm happy to send updates before merging upon review. Optimally, this could be rebased on top of my `tests` branch.